### PR TITLE
Fix light mode styling and add sun/moon toggle icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,26 @@
           </div>
         </div>
         <div class="accountlinks">
-          <label for="theme-toggle" class="theme-toggle-label" title="Toggle theme"></label>
+          <label for="theme-toggle" class="theme-toggle-label" title="Toggle theme">
+            <span class="toggle-moon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+            </span>
+            <span class="toggle-sun" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="5" fill="currentColor" stroke="none"/>
+                <line x1="12" y1="1" x2="12" y2="3" />
+                <line x1="12" y1="21" x2="12" y2="23" />
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                <line x1="1" y1="12" x2="3" y2="12" />
+                <line x1="21" y1="12" x2="23" y2="12" />
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+              </svg>
+            </span>
+          </label>
           <a href="https://www.swiftfolios.com/access/signup">
             <div class="login-button">
               <span>Create Account</span>

--- a/index.html
+++ b/index.html
@@ -578,7 +578,7 @@
 
       removeborder();
       document.getElementById("profile2").style.border = "1px solid #b66ced";
-      drawChart([50, 30, 10, 10], ['#8B5CF6', '#7C3AED', '#6D28D9', '#A78BFA'], labels);
+      drawChart([50, 30, 10, 10], ['#3179F5', '#00D3E0', '#9BF48A', '#F9F871'], labels);
     }
 
     function profile3() {
@@ -590,7 +590,7 @@
 
       removeborder();
       document.getElementById("profile3").style.border = "1px solid blue";
-      drawChart([30, 40, 20, 10], ['#8B5CF6', '#7C3AED', '#6D28D9', '#A78BFA'], labels);
+      drawChart([30, 40, 20, 10], ['#3179F5', '#00D3E0', '#9BF48A', '#F9F871'], labels);
     }
 
     function profile4() {
@@ -602,7 +602,7 @@
 
       removeborder();
       document.getElementById("profile4").style.border = "1px solid #67d098";
-      drawChart([10, 50, 20, 20], ['#8B5CF6', '#7C3AED', '#6D28D9', '#A78BFA'], labels);
+      drawChart([10, 50, 20, 20], ['#3179F5', '#00D3E0', '#9BF48A', '#F9F871'], labels);
     }
 
     function profile5() {
@@ -614,7 +614,7 @@
 
       removeborder();
       document.getElementById("profile5").style.border = "1px solid yellow";
-      drawChart([40, 30, 20, 10], ['#8B5CF6', '#7C3AED', '#6D28D9', '#A78BFA'], labels);
+      drawChart([40, 30, 20, 10], ['#3179F5', '#00D3E0', '#9BF48A', '#F9F871'], labels);
     }
 
     function profile6() {
@@ -626,13 +626,15 @@
 
       removeborder();
       document.getElementById("profile6").style.border = "1px solid orange";
-      drawChart([40, 20, 10, 30], ['#8B5CF6', '#7C3AED', '#6D28D9', '#A78BFA'], labels);
+      drawChart([40, 20, 10, 30], ['#3179F5', '#00D3E0', '#9BF48A', '#F9F871'], labels);
     }
 
   </script>
   <script>
     function drawChart(percentageData, backgroundColours, chartLabels) {
-      Chart.defaults.color = 'rgba(229, 231, 235, 1)';
+      const root = document.querySelector('.app');
+      const textCol = getComputedStyle(root).getPropertyValue('--text').trim() || '#111827';
+      Chart.defaults.color = textCol;
       const ctx = document.getElementById('myChart');
       const data = {
         datasets: [{
@@ -659,7 +661,7 @@
               borderColor: '#374151',
               borderWidth: 1,
               titleColor: '#e5e7eb',
-              bodyColor: '#e5e7eb',
+              bodyColor: textCol,
               bodyFont: {
                 family: 'Open Sans',
               },
@@ -677,7 +679,7 @@
               align: al,
               borderRadius: 30,
               labels: {
-                color: '#e5e7eb',
+                color: textCol,
                 boxWidth: 20,
                 boxHeight: 20,
                 padding: 10,

--- a/index.html
+++ b/index.html
@@ -636,12 +636,13 @@
       const textCol = getComputedStyle(root).getPropertyValue('--text').trim() || '#111827';
       Chart.defaults.color = textCol;
       const ctx = document.getElementById('myChart');
+      const isLight = document.getElementById('theme-toggle')?.checked === true;
       const data = {
         datasets: [{
           data: percentageData,
           backgroundColor: backgroundColours,
-          borderColor: '#1f2937',
-          borderWidth: 2,
+          borderColor: isLight ? 'transparent' : '#1f2937',
+          borderWidth: isLight ? 0 : 2,
           hoverOffset: 5,
         }],
         labels: chartLabels
@@ -657,8 +658,8 @@
               display: false
             },
             tooltip: {
-              backgroundColor: '#111827',
-              borderColor: '#374151',
+              backgroundColor: isLight ? '#ffffff' : '#111827',
+              borderColor: isLight ? '#e5e7eb' : '#374151',
               borderWidth: 1,
               titleColor: '#e5e7eb',
               bodyColor: textCol,

--- a/static-content/index.css
+++ b/static-content/index.css
@@ -2614,7 +2614,7 @@ a { color: var(--text); }
 .brand-info .tagline .tagline2 { color: rgba(255,255,255,0.9); }
 .para, .excl, .private_wealth, .with_mutual, .deserve, .club, .five, .rs, .averagesize, .fifteen,
 .rect3title, .rect3bottom, .rect3bottombottom, .rect4firstrow, .rect4secondrow, .rect4thirdrow,
-.rect6firstrow, .rect7firstrow, .rect7secondrow, .rect7thirdrow, .rect7fourthrow { color: rgba(255,255,255,0.9); }
+.rect6firstrow, .rect7firstrow, .rect7secondrow, .rect7thirdrow, .rect7fourthrow { color: var(--text); }
 
 /* Gradient text for the word "Investments" */
 .investments-purple { color:#A78BFA; }

--- a/static-content/index.css
+++ b/static-content/index.css
@@ -295,7 +295,9 @@ a {
 .hero-sections .hero-footer {
   padding: 0px 3%;
   height: 80px;
+  background:#000;
 }
+.hero-footer .footer-content p{ color:#fff; }
 
 .hero-footer .footer-line {
   width: 100%;
@@ -2606,12 +2608,14 @@ a { color: var(--text); }
               linear-gradient(180deg, #120A24 0%, #0F0A1C 100%);
   color: rgba(255,255,255,0.92);
 }
+#theme-toggle:checked ~ .app .hero-section1 { background:#ffffff; color: var(--light-text); }
 .hero-section2 { background-color:#130e26; background-image:linear-gradient(180deg,#130e26 0%, #100b20 100%); color:#e8e8e8; }
+#theme-toggle:checked ~ .app .hero-section2 { background-color:#fafafa; background-image:none; color: var(--light-text); }
 .rect1, .rect3, .rect4, .rect5, .rect6, .rect7 { background: var(--bg); }
 .topclientsdiv, .rect7inner, .chartarea { background: var(--card); border: 1px solid var(--border); }
-.section1-content .brand-name { color: rgba(255,255,255,0.92); }
-.section1-content .brand-info .tagline { color: #e5e7eb; }
-.brand-info .tagline .tagline2 { color: rgba(255,255,255,0.9); }
+.section1-content .brand-name { color: var(--text); }
+.section1-content .brand-info .tagline { color: var(--text); }
+.brand-info .tagline .tagline2 { color: var(--text); }
 .para, .excl, .private_wealth, .with_mutual, .deserve, .club, .five, .rs, .averagesize, .fifteen,
 .rect3title, .rect3bottom, .rect3bottombottom, .rect4firstrow, .rect4secondrow, .rect4thirdrow,
 .rect6firstrow, .rect7firstrow, .rect7secondrow, .rect7thirdrow, .rect7fourthrow { color: var(--text); }

--- a/static-content/index.css
+++ b/static-content/index.css
@@ -2627,7 +2627,7 @@ a { color:#cbd5e1; }
 .slottext { color:#fff; }
 
 /* reduce extra gaps from fixed heights */
-.rect2, .rect3, .rect4, .rect6, .rect7 { height: auto !important; min-height: unset; }
+.rect2, .rect3, .rect4, .rect6, .rect7 {  }
 .rect3bottombottom { background:#3179F5; border:1px solid #3179F5; color:#fff; }
 .rect3bottombottom a { color:#fff; }
 .rect3bottombottom:hover { background:#2563eb; }
@@ -2636,3 +2636,16 @@ a { color:#cbd5e1; }
 .service-box { background-color: #1a1333; color: #e8e8e8; border: 1px solid rgba(167,139,250,0.25); }
 .service-box:hover { background-image: linear-gradient(90deg, #2b1b54 0%, #221843 100%); color: white; }
 .disclaimer { color: #cbd5e1; }
+
+/* Inline header theme toggle (left of Create Account) */
+.accountlinks { align-items: center; gap: 10px; }
+.accountlinks .theme-toggle-label{ position: static; width: 30px; height: 30px; padding: 0; display: inline-flex; align-items: center; justify-content: center; border-radius: 999px; background: linear-gradient(180deg,#2b1b54,#221843); color: #fff; border: 1px solid var(--border); box-shadow: none; }
+.theme-toggle-label svg{ width:16px; height:16px; }
+.theme-toggle-label .toggle-sun{ display:none; }
+#theme-toggle:checked ~ .app .theme-toggle-label .toggle-sun{ display:inline-block; }
+#theme-toggle:checked ~ .app .theme-toggle-label .toggle-moon{ display:none; }
+
+/* Readability tweaks */
+.app .profileboxright, .app .box-title, .app .box-content, .app .arrows section .box-title { color: var(--text); }
+.app .arrows section .box-title:before { color: rgba(229,231,235,0.8); }
+.app .rect6secondrow span { color: var(--text); }

--- a/static-content/index.css
+++ b/static-content/index.css
@@ -2596,8 +2596,8 @@ html, body { background: var(--dark-bg); color: var(--dark-text); }
 }
 
 /* apply vars */
-.app, .hero-sections, .rect1, .rect2, .rect3, .rect4, .rect5, .rect6, .rect7 { background: var(--bg); color: var(--text); }
-a { color:#cbd5e1; }
+.app, .hero-sections, .rect1, .rect3, .rect4, .rect5, .rect6, .rect7 { background: var(--bg); color: var(--text); }
+a { color: var(--text); }
 ::selection { background:#A78BFA; color:#0B1020; }
 .nifty50 { background: transparent !important; }
 .hero-section1 {
@@ -2633,8 +2633,8 @@ a { color:#cbd5e1; }
 .rect3bottombottom:hover { background:#2563eb; }
 
 .trade-types-main { color: #a5b4fc; }
-.service-box { background-color: #1a1333; color: #e8e8e8; border: 1px solid rgba(167,139,250,0.25); }
-.service-box:hover { background-image: linear-gradient(90deg, #2b1b54 0%, #221843 100%); color: white; }
+.service-box { background: var(--card); color: var(--text); border: 1px solid var(--border); }
+.service-box:hover { background:#3179F5; color:#fff; border-color:#3179F5; }
 .disclaimer { color: #cbd5e1; }
 
 /* Inline header theme toggle (left of Create Account) */
@@ -2647,5 +2647,11 @@ a { color:#cbd5e1; }
 
 /* Readability tweaks */
 .app .profileboxright, .app .box-title, .app .box-content, .app .arrows section .box-title { color: var(--text); }
-.app .arrows section .box-title:before { color: rgba(229,231,235,0.8); }
+/* Accordion arrow color follows theme */
+.app .arrows section .box-title:before { color: rgba(0,0,0,0.4); }
+#theme-toggle:not(:checked) ~ .app .arrows section .box-title:before { color: rgba(229,231,235,0.8); }
 .app .rect6secondrow span { color: var(--text); }
+/* Cards in both themes */
+.profilebox { background: var(--card); border:1px solid var(--border); }
+.box { background: var(--card); border:1px solid var(--border); }
+.rect7inner, .topclientsdiv, .chartarea { background: var(--card); border:1px solid var(--border); }


### PR DESCRIPTION
## Purpose
The user requested comprehensive improvements to the light/dark mode toggle functionality and visual consistency. Their main goals were to:
- Add proper sun/moon icons to the theme toggle button positioned left of the "Create Account" button
- Fix light mode styling issues where certain sections (hero, services) remained dark when toggling to light mode
- Improve text readability across both themes by ensuring proper contrast
- Change chart colors from purple to a more colorful palette and remove borders in light mode
- Make the footer consistently black with white text
- Ensure all UI elements properly respond to theme changes

## Code changes
- **Theme toggle UI**: Added sun and moon SVG icons to the toggle button with proper positioning and styling
- **Light mode fixes**: Updated hero sections and service areas to properly switch to light backgrounds when in light mode
- **Chart improvements**: 
  - Replaced purple color scheme with blue/cyan/green/yellow palette
  - Made chart borders transparent in light mode
  - Updated legend and tooltip colors to follow theme variables
- **Footer styling**: Set footer background to black with white text consistently
- **Text readability**: Updated text colors throughout to use CSS custom properties for proper theme-aware contrast
- **Card styling**: Ensured all cards, boxes, and content areas use theme-appropriate backgrounds and borders

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8a48bbcea3f5430ebbae88e0d34621f6/quantum-den)

👀 [Preview Link](https://8a48bbcea3f5430ebbae88e0d34621f6-quantum-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8a48bbcea3f5430ebbae88e0d34621f6</projectId>-->
<!--<branchName>quantum-den</branchName>-->